### PR TITLE
BTAT-8008 - Added feature and logic to get comms pref from API#1363

### DIFF
--- a/app/config/ConfigKeys.scala
+++ b/app/config/ConfigKeys.scala
@@ -29,6 +29,7 @@ object ConfigKeys {
   val stubAgentClientLookupFeature: String = "features.stubAgentClientLookup.enabled"
   val emailVerifiedFeature: String = "features.emailVerifiedFeature.enabled"
   val agentBulkPaperFeature: String = "features.agentBulkPaper.enabled"
+  val contactPrefMigrationFeature: String = "features.contactPrefMigration.enabled"
 
   val accessibilityReportUrl: String = "accessibilityReport.url"
   val accessibilityReportHost: String = "accessibilityReport.host"

--- a/app/config/features/Features.scala
+++ b/app/config/features/Features.scala
@@ -27,4 +27,5 @@ class Features @Inject()(implicit config: Configuration) {
   val stubContactPreferencesFeature = new Feature(ConfigKeys.stubContactPreferencesFeature)
   val emailVerifiedFeature = new Feature(ConfigKeys.emailVerifiedFeature)
   val agentBulkPaperFeature = new Feature(ConfigKeys.agentBulkPaperFeature)
+  val contactPrefMigrationFeature = new Feature(ConfigKeys.contactPrefMigrationFeature)
 }

--- a/app/models/circumstanceInfo/CircumstanceDetails.scala
+++ b/app/models/circumstanceInfo/CircumstanceDetails.scala
@@ -25,7 +25,8 @@ case class CircumstanceDetails(customerDetails: CustomerDetails,
                                changeIndicators: Option[ChangeIndicators],
                                returnPeriod: Option[ReturnPeriod],
                                partyType: Option[String],
-                               emailVerified: Option[Boolean])
+                               emailVerified: Option[Boolean],
+                               commsPreference: Option[String])
 
 object CircumstanceDetails extends JsonReadUtil {
 
@@ -34,13 +35,15 @@ object CircumstanceDetails extends JsonReadUtil {
   private val partyTypePath = __ \ "partyType"
   private val changeIndicatorsPath = __ \ "changeIndicators"
   private val emailVerifiedPath = __ \ "ppob" \ "contactDetails" \ "emailVerified"
+  private val commsPreferencePath = __ \ "commsPreference"
 
   implicit val reads: Reads[CircumstanceDetails] = (
     customerDetailsPath.read[CustomerDetails] and
     changeIndicatorsPath.readOpt[ChangeIndicators] and
     returnPeriodPath.readOpt[ReturnPeriod] and
     partyTypePath.readOpt[String] and
-    emailVerifiedPath.readOpt[Boolean]
+    emailVerifiedPath.readOpt[Boolean] and
+    commsPreferencePath.readOpt[String]
   ) (CircumstanceDetails.apply _)
 
   implicit val writes: Writes[CircumstanceDetails] = (
@@ -48,7 +51,8 @@ object CircumstanceDetails extends JsonReadUtil {
     changeIndicatorsPath.writeNullable[ChangeIndicators] and
     returnPeriodPath.writeNullable[ReturnPeriod] and
     partyTypePath.writeNullable[String] and
-    emailVerifiedPath.writeNullable[Boolean]
+    emailVerifiedPath.writeNullable[Boolean] and
+    commsPreferencePath.writeNullable[String]
   ) (unlift(CircumstanceDetails.unapply))
 
 }

--- a/app/testOnly/controllers/FeatureSwitchController.scala
+++ b/app/testOnly/controllers/FeatureSwitchController.scala
@@ -33,7 +33,8 @@ class FeatureSwitchController @Inject()(val messagesApi: MessagesApi,
       FeatureSwitchModel(
         stubContactPreferencesFeature = appConfig.features.stubContactPreferencesFeature(),
         stubAgentClientLookupFeature = appConfig.features.stubAgentClientLookup(),
-        agentBulkPaperFeature = appConfig.features.agentBulkPaperFeature()
+        agentBulkPaperFeature = appConfig.features.agentBulkPaperFeature(),
+        contactPrefMigrationFeature = appConfig.features.contactPrefMigrationFeature()
       )
     )))
   }
@@ -49,6 +50,7 @@ class FeatureSwitchController @Inject()(val messagesApi: MessagesApi,
     appConfig.features.stubContactPreferencesFeature(model.stubContactPreferencesFeature)
     appConfig.features.stubAgentClientLookup(model.stubAgentClientLookupFeature)
     appConfig.features.agentBulkPaperFeature(model.agentBulkPaperFeature)
+    appConfig.features.contactPrefMigrationFeature(model.contactPrefMigrationFeature)
     Redirect(routes.FeatureSwitchController.featureSwitch())
   }
 }

--- a/app/testOnly/forms/FeatureSwitchForm.scala
+++ b/app/testOnly/forms/FeatureSwitchForm.scala
@@ -27,7 +27,8 @@ object FeatureSwitchForm {
     mapping(
       ConfigKeys.stubContactPreferencesFeature -> boolean,
       ConfigKeys.stubAgentClientLookupFeature -> boolean,
-      ConfigKeys.agentBulkPaperFeature -> boolean
+      ConfigKeys.agentBulkPaperFeature -> boolean,
+      ConfigKeys.contactPrefMigrationFeature -> boolean
     )(FeatureSwitchModel.apply)(FeatureSwitchModel.unapply)
   )
 }

--- a/app/testOnly/models/FeatureSwitchModel.scala
+++ b/app/testOnly/models/FeatureSwitchModel.scala
@@ -16,7 +16,7 @@
 
 package testOnly.models
 
-case class FeatureSwitchModel(
-                              stubContactPreferencesFeature: Boolean,
+case class FeatureSwitchModel(stubContactPreferencesFeature: Boolean,
                               stubAgentClientLookupFeature: Boolean,
-                              agentBulkPaperFeature: Boolean)
+                              agentBulkPaperFeature: Boolean,
+                              contactPrefMigrationFeature: Boolean)

--- a/app/testOnly/views/featureSwitch.scala.html
+++ b/app/testOnly/views/featureSwitch.scala.html
@@ -17,28 +17,28 @@
 @import config.ConfigKeys
 @import helper.CSRF
 @import testOnly.models._
-@import testOnly.forms.FeatureSwitchForm
 
 @(form: Form[FeatureSwitchModel])(implicit request: Request[_], messages: Messages, appConfig: config.AppConfig)
 
-@views.html.main_template(title = messages("featureSwitch.title"), bodyClasses = None, appConfig = appConfig) {
+@views.html.main_template(title = messages("featureSwitch.title"), appConfig = appConfig) {
 
-    @helper.form(action = testOnly.controllers.routes.FeatureSwitchController.submitFeatureSwitch) {
-        @CSRF.formField
+  @helper.form(action = testOnly.controllers.routes.FeatureSwitchController.submitFeatureSwitch) {
+    @CSRF.formField
 
-        <div class="form-group" style="border-radius: 25px;
-            background: #C9EDD9;
-            padding: 25px;">
-            <fieldset>
-                <legend>
-                    <p class="bold-medium" style="margin-bottom: 10px;">VAT Return Period Frontend Features</p>
-                </legend>
-                @views.html.templates.inputs.singleCheckbox(form(ConfigKeys.stubContactPreferencesFeature), "Stub Contact Preferences")
-                @views.html.templates.inputs.singleCheckbox(form(ConfigKeys.stubAgentClientLookupFeature), "Stub Agent Client Lookup")
-                @views.html.templates.inputs.singleCheckbox(form(ConfigKeys.agentBulkPaperFeature), "Agent Bulk Paper Content")
-            </fieldset>
-        </div>
+    <div class="form-group" style="border-radius: 25px;
+        background: #C9EDD9;
+        padding: 25px;">
+      <fieldset>
+        <legend>
+            <p class="bold-medium" style="margin-bottom: 10px;">VAT Return Period Frontend Features</p>
+        </legend>
+        @views.html.templates.inputs.singleCheckbox(form(ConfigKeys.stubContactPreferencesFeature), "Stub Contact Preferences")
+        @views.html.templates.inputs.singleCheckbox(form(ConfigKeys.stubAgentClientLookupFeature), "Stub Agent Client Lookup")
+        @views.html.templates.inputs.singleCheckbox(form(ConfigKeys.agentBulkPaperFeature), "Agent Bulk Paper Content")
+        @views.html.templates.inputs.singleCheckbox(form(ConfigKeys.contactPrefMigrationFeature), "Retrieve contact pref from vat-subscription")
+      </fieldset>
+    </div>
 
-        <button class="button" type="submit" id="continue-button">@messages("featureSwitch.submit")</button>
-    }
+    <button class="button" type="submit" id="continue-button">@messages("featureSwitch.submit")</button>
+  }
 }

--- a/app/views/returnFrequency/change_return_frequency_confirmation.scala.html
+++ b/app/views/returnFrequency/change_return_frequency_confirmation.scala.html
@@ -16,6 +16,7 @@
 
 @import views.html.templates.updateClient
 @import models.auth.User
+@import models.contactPreferences.ContactPreference.{digital, paper}
 
 @(clientName: Option[String] = None, agentEmail: Option[String] = None, contactPref: Option[String] = None, emailVerified: Boolean = false)(implicit user : User[_], messages: Messages, appConfig: config.AppConfig)
 
@@ -69,8 +70,8 @@
     } else {
 
         @contactPref match {
-            case Some("DIGITAL") => {<p>@messages(if(emailVerified){"contact_preference.email"}else{"contact_preference.digital"})</p>}
-            case Some("PAPER") => {<p>@messages("contact_preference.paper")</p>}
+            case Some(`digital`) => {<p>@messages(if(emailVerified){"contact_preference.email"}else{"contact_preference.digital"})</p>}
+            case Some(`paper`) => {<p>@messages("contact_preference.paper")</p>}
             case _ => {<p>@messages("contact_preference.contactPrefError")</p>}
         }
         <p>@messages("contact_preference.contact")</p>

--- a/build.sbt
+++ b/build.sbt
@@ -54,14 +54,14 @@ lazy val coverageSettings: Seq[Setting[_]] = {
 
 val compile = Seq(
   play.sbt.PlayImport.ws,
-  "uk.gov.hmrc" %% "govuk-template" % "5.52.0-play-25",
-  "uk.gov.hmrc" %% "play-ui" % "8.8.0-play-25",
-  "uk.gov.hmrc" %% "bootstrap-play-25" % "5.2.0",
-  "uk.gov.hmrc" %% "play-partials" % "6.9.0-play-25",
-  "uk.gov.hmrc" %% "auth-client" % "2.33.0-play-25",
+  "uk.gov.hmrc" %% "govuk-template" % "5.55.0-play-25",
+  "uk.gov.hmrc" %% "play-ui" % "8.11.0-play-25",
+  "uk.gov.hmrc" %% "bootstrap-play-25" % "5.3.0",
+  "uk.gov.hmrc" %% "play-partials" % "6.11.0-play-25",
+  "uk.gov.hmrc" %% "auth-client" % "3.0.0-play-25",
   "uk.gov.hmrc" %% "domain" % "5.6.0-play-25",
   "org.typelevel" %% "cats" % "0.9.0",
-  "uk.gov.hmrc" %% "play-whitelist-filter" % "3.1.0-play-25",
+  "uk.gov.hmrc" %% "play-whitelist-filter" % "3.4.0-play-25",
   "uk.gov.hmrc" %% "play-language" % "3.4.0"
 )
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -62,6 +62,7 @@ features {
   stubAgentClientLookup.enabled = true
   emailVerifiedFeature.enabled = true
   agentBulkPaper.enabled = true
+  contactPrefMigration.enabled = true
 }
 
 microservice {

--- a/it/stubs/VatSubscriptionStub.scala
+++ b/it/stubs/VatSubscriptionStub.scala
@@ -18,6 +18,7 @@ package stubs
 
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
 import models.circumstanceInfo.{ChangeIndicators, CircumstanceDetails, CustomerDetails}
+import models.contactPreferences.ContactPreference.digital
 import models.returnFrequency.Monthly
 import play.api.http.Status.OK
 import play.api.libs.json.{JsValue, Json}
@@ -44,29 +45,31 @@ object VatSubscriptionStub extends WireMockMethods {
       "returnPeriod" -> true,
       "annualAccounting" -> false
     ),
-    "partyType" -> Some("2")
+    "partyType" -> Some("2"),
+    "commsPreference" -> digital
   )
 
-  val circumstanceDetailsModelMax =
+  val circumstanceDetailsModelMax: CircumstanceDetails =
     CircumstanceDetails(
       CustomerDetails(Some("bob"), Some("smith"), Some("org name"), Some("trading name")),
       Some(ChangeIndicators(Some(true))),
       Some(Monthly),
       Some(partyType),
-      Some(true)
+      Some(true),
+      Some(digital)
     )
 
-  val circumstanceDetailsModelMin =
+  val circumstanceDetailsModelMin: CircumstanceDetails =
     CircumstanceDetails(
       CustomerDetails(None, None, None, None),
+      None,
       None,
       None,
       None,
       None
     )
 
-  def getClientDetailsSuccess(vrn: String)(customerDetails: CircumstanceDetails): StubMapping = {
+  def getClientDetailsSuccess(vrn: String)(customerDetails: CircumstanceDetails): StubMapping =
     when(method = GET, uri = subscriptionUri(vrn))
       .thenReturn(status = OK, body = Json.toJson(customerDetails))
-  }
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -20,13 +20,13 @@ resolvers += "HMRC Releases" at "https://dl.bintray.com/hmrc/releases"
 
 resolvers += "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.6.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.9.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.1.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.0.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.2.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.3.0")
 
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.19")
 

--- a/test/assets/CircumstanceDetailsTestConstants.scala
+++ b/test/assets/CircumstanceDetailsTestConstants.scala
@@ -17,6 +17,7 @@
 package assets
 
 import models.circumstanceInfo.{ChangeIndicators, CircumstanceDetails, CustomerDetails}
+import models.contactPreferences.ContactPreference.digital
 import models.returnFrequency.Monthly
 import play.api.libs.json.{JsValue, Json}
 
@@ -39,63 +40,70 @@ object CircumstanceDetailsTestConstants {
       "returnPeriod" -> true,
       "annualAccounting" -> false
     ),
-    "partyType" -> Some(partyType)
+    "partyType" -> Some(partyType),
+    "commsPreference" -> digital
   )
 
   val circumstanceDetailsJsonMin: JsValue = Json.obj(
     "customerDetails" -> Json.obj()
   )
 
-  val circumstanceDetailsModelMax =
+  val circumstanceDetailsModelMax: CircumstanceDetails =
     CircumstanceDetails(
       CustomerDetails(Some("bob"), Some("smith"), Some("org name"), Some("trading name")),
       Some(ChangeIndicators(Some(true))),
       Some(Monthly),
       Some(partyType),
-      Some(true)
+      Some(true),
+      Some(digital)
     )
 
-  val circumstanceDetailsModelMaxAA =
+  val circumstanceDetailsModelMaxAA: CircumstanceDetails =
     CircumstanceDetails(
       CustomerDetails(Some("bob"), Some("smith"), Some("org name"), Some("trading name")),
       Some(ChangeIndicators(Some(false), annualAccounting = true)),
       Some(Monthly),
       Some(partyType),
-      Some(true)
+      Some(true),
+      Some(digital)
     )
 
-  val circumstanceDetailsModelMin =
+  val circumstanceDetailsModelMin: CircumstanceDetails =
     CircumstanceDetails(
       CustomerDetails(None, None, None, None),
+      None,
       None,
       None,
       None,
       None
     )
 
-  val circumstanceDetailsModelMinAA =
+  val circumstanceDetailsModelMinAA: CircumstanceDetails =
     CircumstanceDetails(
       CustomerDetails(None, None, None, None),
       Some(ChangeIndicators(Some(false), annualAccounting = true)),
       None,
       None,
+      None,
       None
     )
 
-  val circumstanceDetailsNoPending =
+  val circumstanceDetailsNoPending: CircumstanceDetails =
     CircumstanceDetails(
       CustomerDetails(Some("bob"), Some("smith"), Some("org name"), Some("trading name")),
       Some(ChangeIndicators(Some(false))),
       Some(Monthly),
       Some(partyType),
+      None,
       None
     )
 
-  val circumstanceDetailsNoChangeIndicator =
+  val circumstanceDetailsNoChangeIndicator: CircumstanceDetails =
     CircumstanceDetails(
       CustomerDetails(Some("bob"), Some("smith"), Some("org name"), Some("trading name")),
       None,
       Some(Monthly),
+      None,
       None,
       None
     )


### PR DESCRIPTION
Please ensure this is merged too: https://github.com/hmrc/app-config-production/pull/7505

**Note:** this work can't be manually tested without the bug fix for vat-subscription (BTAT-8015)

# Pull Request Checklist
* [x] Branch is rebased with master
* [x] Added Unit Tests for changed functionality
* [x] Ran `sbt clean compile coverage test it:test coverageReport`, all tests pass and coverage meets minimum
* [x] Checked libraries are up to date with `sbt validate`. (If applicable) library updates are done in a separate, single commit
* [x] Ran [change-vat-acceptance-tests](https://github.com/hmrc/change-vat-acceptance-tests) (see README of repo)
* [ ] Ran [change-vat-performance-tests](https://github.com/hmrc/change-vat-performance-tests) (see README of repo)
* [x] (If applicable) raised app-config-* PRs
* [ ] (If applicable) ran Wave test for changes to views
* [ ] (If applicable) added Integration Test
