### PR TITLE
BTAT-8248 Moved service info content, langauge toggle and back links out of <main>

### DIFF
--- a/app/views/GovUkWrapper.scala.html
+++ b/app/views/GovUkWrapper.scala.html
@@ -34,7 +34,7 @@
 
 @(appConfig: AppConfig,
   title: String,
-  mainClass: Option[String] = None,
+  backLinkContent: Option[Html] = None,
   mainDataAttributes: Option[Html] = None,
   bodyClasses: Option[String] = None,
   sidebar: Html = HtmlFormat.empty,
@@ -95,7 +95,31 @@
       navLinks = Some(headerNavLinks))
 }
 
-@afterHeader = {}
+@phaseBanner = {
+  <div class="beta-banner">
+    <p>
+      <strong class="phase-tag">@messages("banner.phaseName")</strong>
+      <span>@messages("feedback.before")
+      <a href="@appConfig.betaFeedbackUrl">@messages("feedback.link")</a>
+        @messages("feedback.after")
+      </span>
+    </p>
+  </div>
+}
+
+@afterHeader = {
+  <div class="centered-content">
+    <div class="service-info">
+      @phaseBanner
+    </div>
+    @views.html.language_selection(
+      appConfig.languageMap,
+      appConfig.routeToSwitchLanguage,
+      customClass = Some("text--right")
+    )
+    @backLinkContent
+  </div>
+}
 
 @bodyEnd = {
     @footer(
@@ -108,18 +132,6 @@
 
 @footerTop = {}
 
-@phaseBanner = {
-    <div class="beta-banner">
-        <p>
-            <strong class="phase-tag">@messages("banner.phaseName")</strong>
-            <span>@messages("feedback.before")
-                <a href="@appConfig.betaFeedbackUrl">@messages("feedback.link")</a>
-                @messages("feedback.after")
-            </span>
-        </p>
-    </div>
-}
-
 @serviceInfoHtml = {
     @serviceInfo(
       betaBanner = phaseBanner,
@@ -129,11 +141,6 @@
 }
 
 @mainContentHeaderContent = {
-      @views.html.language_selection(
-           appConfig.languageMap,
-           appConfig.routeToSwitchLanguage,
-           customClass = Some("text--right")
-    )
     @if(contentHeader.isDefined) {
         @mainContentHeader(contentHeader = contentHeader.get)
     }
@@ -144,12 +151,11 @@
 @content = {
     @mainContent(
       article = mainBody,
-      mainClass = mainClass,
       mainDataAttributes = mainDataAttributes,
       mainContentHeader = mainContentHeaderContent,
-      serviceInfo = serviceInfoHtml,
       getHelpForm = getHelpForm,
-      sidebar = sidebar)
+      sidebar = sidebar
+    )
 }
 
 @hmrcGovUkTemplate(Some(title), bodyClasses)(

--- a/app/views/MainTemplate.scala.html
+++ b/app/views/MainTemplate.scala.html
@@ -25,7 +25,7 @@
   sidebarLinks: Option[Html] = None,
   contentHeader: Option[Html] = None,
   bodyClasses: Option[String] = None,
-  mainClass: Option[String] = None,
+  backLinkContent: Option[Html] = None,
   scriptElem: Option[Html] = None,
   showSignOut: Boolean = true,
   user: Option[User[_]] = None)(mainContent: Html)(implicit messages: Messages)
@@ -42,7 +42,7 @@
 
 @govUkWrapper(appConfig = appConfig,
   title = messages("common.pageTitle", title, titleServiceName),
-  mainClass = mainClass,
+  backLinkContent = backLinkContent,
   bodyClasses = bodyClasses,
   sidebar = sidebarContent,
   contentHeader = contentHeader,

--- a/app/views/returnFrequency/ChooseDates.scala.html
+++ b/app/views/returnFrequency/ChooseDates.scala.html
@@ -22,8 +22,7 @@
 @import views.html.MainTemplate
 @import uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
 
-@this(mainTemplate: MainTemplate, errorSummary: ErrorSummary, radioGroup: RadioGroup,
-      helpersForm: FormWithCSRF)
+@this(mainTemplate: MainTemplate, errorSummary: ErrorSummary, radioGroup: RadioGroup, helpersForm: FormWithCSRF)
 
 @(form: Form[ReturnDatesModel], current: ReturnPeriod)(implicit user : User[_], messages: Messages, appConfig: config.AppConfig)
 
@@ -40,13 +39,15 @@
     }
 }
 
+@backLink = {
+  <a class="link-back" href='@appConfig.manageVatUrl'>@messages("base.back")</a>
+}
+
 @mainTemplate(
   title = if(form.errors.nonEmpty) messages("common.error.prefixTitle", messages("return_frequency.title")) else messages("return_frequency.title"),
-  bodyClasses = None,
   appConfig = appConfig,
+  backLinkContent = Some(backLink),
   user = Some(user)) {
-
-  <a class="link-back" href='@appConfig.manageVatUrl'>@messages("base.back")</a>
 
   @errorSummary("common.errorSummary.heading", form)
 
@@ -71,5 +72,4 @@
       </button>
 
   }
-
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -34,7 +34,6 @@ play.modules.enabled += "uk.gov.hmrc.play.bootstrap.AuditModule"
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.graphite.GraphiteMetricsModule"
 
 # Provides an implementation and configures all filters required by a Platform frontend microservice.
-play.modules.enabled += "uk.gov.hmrc.play.bootstrap.FrontendModule"
 play.http.filters = "config.filters.ServiceFilters"
 
 # Default http client
@@ -50,7 +49,7 @@ play.filters.headers.xssProtection = "1"
 # ~~~~
 # Additional play modules can be added here
 play.modules.enabled += "com.kenshoo.play.metrics.PlayModule"
-play.modules.enabled += "uk.gov.hmrc.play.bootstrap.FrontendModule"
+play.modules.enabled += "uk.gov.hmrc.play.bootstrap.frontend.FrontendModule"
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientModule"
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.AuditModule"
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.AuthModule"

--- a/run.sh
+++ b/run.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-	sbt 'run 9167 -Dlogger.resource=logback-test.xml -Dapplication.router=testOnly.Routes'
+	sbt 'run 9167 -Dlogger.resource=logback-test.xml -Dplay.http.router=testOnly.Routes'

--- a/test/config/ServiceErrorHandlerSpec.scala
+++ b/test/config/ServiceErrorHandlerSpec.scala
@@ -29,7 +29,7 @@ class ServiceErrorHandlerSpec extends ViewBaseSpec {
 
   object Selectors {
     val pageHeading = "h1"
-    val message = "#content > p:nth-child(3)"
+    val message = "#content > p:nth-child(2)"
   }
 
   "The not found template" should {


### PR DESCRIPTION
I repurposed the `mainClass` parameter (unused) of our templates in favour of a `backLinkContent` parameter where we can pass in HTML for back links. I also restructured the GOVUK template to move the back links and language toggle out of the `<main>` HTML, as well as the service info content (beta banner) which was necessary to keep elements in the correct vertical position on the page.