### PR TITLE
BTAT-9278 Migrated to HmrcStandardHeader; updated dependencies

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -9,10 +9,6 @@ $hmrc-assets-path: "/vat-through-software/account/returns/assets/lib/hmrc-fronte
   font-weight: bold;
 }
 
-.govuk-header__content > nav {
-  float: right;
-}
-
 .govuk-main-wrapper {
   padding-top: 0;
 }
@@ -25,11 +21,4 @@ $hmrc-assets-path: "/vat-through-software/account/returns/assets/lib/hmrc-fronte
   text-decoration: none;
   pointer-events: none;
   cursor: default;
-}
-
-.js-enabled .govuk-header__menu-button {
-  display: none;
-}
-.js-enabled .govuk-header__navigation {
-  display: block;
 }

--- a/app/audit/AuditService.scala
+++ b/app/audit/AuditService.scala
@@ -35,7 +35,7 @@ class AuditService @Inject()(appConfig: FrontendAppConfig, auditConnector: Audit
 
   implicit val extendedDataEventWrites: Writes[ExtendedDataEvent] = Json.writes[ExtendedDataEvent]
 
-  val referrer: HeaderCarrier => String = _.headers.find(_._1 == HeaderNames.REFERER).map(_._2).getOrElse("-")
+  val referrer: HeaderCarrier => String = _.extraHeaders.find(_._1 == HeaderNames.REFERER).map(_._2).getOrElse("-")
 
   def extendedAudit(auditModel: ExtendedAuditModel, path: Option[String] = None)(implicit hc: HeaderCarrier, ec: ExecutionContext): Unit = {
     val extendedDataEvent = toExtendedDataEvent(appConfig.appName, auditModel, path.fold(referrer(hc))(x => x))

--- a/app/config/filters/ServiceFilters.scala
+++ b/app/config/filters/ServiceFilters.scala
@@ -17,11 +17,10 @@
 package config.filters
 
 import javax.inject.Inject
-import play.api.http.DefaultHttpFilters
+import play.api.http.{DefaultHttpFilters, EnabledFilters}
 import play.filters.csrf.CSRFFilter
-import uk.gov.hmrc.play.bootstrap.frontend.filters.FrontendFilters
 
-class ServiceFilters @Inject()(defaultFilters: FrontendFilters,
+class ServiceFilters @Inject()(defaultFilters: EnabledFilters,
                                excludingCSRFFilter: ExcludingCSRFFilter)
   extends DefaultHttpFilters({
     defaultFilters.filters.filterNot(f => f.isInstanceOf[CSRFFilter]) :+ excludingCSRFFilter

--- a/app/controllers/SignOutController.scala
+++ b/app/controllers/SignOutController.scala
@@ -24,8 +24,8 @@ import services.EnrolmentsAuthService
 import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals
 import uk.gov.hmrc.auth.core.{AffinityGroup, AuthorisationException}
 import uk.gov.hmrc.http.HeaderCarrier
-import uk.gov.hmrc.play.HeaderCarrierConverter
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
+import uk.gov.hmrc.play.http.HeaderCarrierConverter
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -37,8 +37,7 @@ class SignOutController @Inject()(enrolmentsAuthService: EnrolmentsAuthService,
 
   def signOut(feedbackOnSignOut: Boolean) : Action[AnyContent] = Action.async { implicit request =>
 
-    implicit val hc: HeaderCarrier =
-      HeaderCarrierConverter.fromHeadersAndSession(request.headers, Some(request.session))
+    implicit val hc: HeaderCarrier = HeaderCarrierConverter.fromRequestAndSession(request, request.session)
 
     if(feedbackOnSignOut) {
       enrolmentsAuthService.authorised.retrieve(Retrievals.affinityGroup) {

--- a/app/controllers/predicates/InFlightAnnualAccountingPredicate.scala
+++ b/app/controllers/predicates/InFlightAnnualAccountingPredicate.scala
@@ -18,6 +18,7 @@ package controllers.predicates
 
 import common.SessionKeys.ANNUAL_ACCOUNTING_PENDING
 import config.{AppConfig, ServiceErrorHandler}
+
 import javax.inject.Inject
 import models.auth.User
 import models.circumstanceInfo.ChangeIndicators
@@ -27,7 +28,7 @@ import play.api.mvc.Results.{Ok, Redirect}
 import play.api.mvc.{ActionRefiner, Result}
 import services.CustomerCircumstanceDetailsService
 import uk.gov.hmrc.http.HeaderCarrier
-import uk.gov.hmrc.play.HeaderCarrierConverter
+import uk.gov.hmrc.play.http.HeaderCarrierConverter
 import views.html.annualAccounting.PreventLeaveAnnualAccounting
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -42,7 +43,7 @@ class InFlightAnnualAccountingPredicate @Inject()(customerCircumstancesService: 
 
   override def refine[A](request: User[A]): Future[Either[Result, User[A]]] = {
 
-    implicit val hc: HeaderCarrier = HeaderCarrierConverter.fromHeadersAndSession(request.headers, Some(request.session))
+    implicit val hc: HeaderCarrier = HeaderCarrierConverter.fromRequestAndSession(request, request.session)
     implicit val user: User[A] = request
 
     user.session.get(ANNUAL_ACCOUNTING_PENDING) match {

--- a/app/controllers/predicates/InFlightReturnFrequencyPredicate.scala
+++ b/app/controllers/predicates/InFlightReturnFrequencyPredicate.scala
@@ -18,6 +18,7 @@ package controllers.predicates
 
 import common.SessionKeys.CURRENT_RETURN_FREQUENCY
 import config.{AppConfig, ServiceErrorHandler}
+
 import javax.inject.Inject
 import models.auth.User
 import models.circumstanceInfo.ChangeIndicators
@@ -27,7 +28,7 @@ import play.api.mvc.Results.Redirect
 import play.api.mvc.{ActionRefiner, MessagesControllerComponents, Result}
 import services.CustomerCircumstanceDetailsService
 import uk.gov.hmrc.http.HeaderCarrier
-import uk.gov.hmrc.play.HeaderCarrierConverter
+import uk.gov.hmrc.play.http.HeaderCarrierConverter
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -42,7 +43,7 @@ class InFlightReturnFrequencyPredicate @Inject()(customerCircumstancesService: C
 
   override def refine[A](request: User[A]): Future[Either[Result, User[A]]] = {
 
-    implicit val hc: HeaderCarrier = HeaderCarrierConverter.fromHeadersAndSession(request.headers, Some(request.session))
+    implicit val hc: HeaderCarrier = HeaderCarrierConverter.fromRequestAndSession(request, request.session)
     implicit val user: User[A] = request
 
     user.session.get(CURRENT_RETURN_FREQUENCY) match {

--- a/app/testOnly/views/FeatureSwitch.scala.html
+++ b/app/testOnly/views/FeatureSwitch.scala.html
@@ -15,7 +15,6 @@
  *@
 
 @import config.ConfigKeys
-@import uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
 @import testOnly.models._
 @import views.html.MainTemplate
 

--- a/app/testOnly/views/StubAgentClientLookup.scala.html
+++ b/app/testOnly/views/StubAgentClientLookup.scala.html
@@ -14,7 +14,6 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
 @import testOnly.models.StubAgentClientLookupModel
 @import views.html.MainTemplate
 

--- a/app/views/MainTemplate.scala.html
+++ b/app/views/MainTemplate.scala.html
@@ -15,27 +15,24 @@
  *@
 
 @import config.AppConfig
+@import uk.gov.hmrc.hmrcfrontend.views.config.StandardBetaBanner
 @import uk.gov.hmrc.hmrcfrontend.views.html.helpers._
-@import uk.gov.hmrc.govukfrontend.views.viewmodels.header.Header
-@import uk.gov.hmrc.play.views.html.layouts.TrackingConsentSnippet
 @import models.auth.User
 
-
 @this(govukLayout: GovukLayout,
-    govukHeader: GovukHeader,
-    govukPhaseBanner: GovukPhaseBanner,
-    hmrcReportTechnicalIssue: HmrcReportTechnicalIssue,
-    hmrcLanguageSelect: HmrcLanguageSelect,
-    hmrcTimeoutDialog: HmrcTimeoutDialog,
-    hmrcStandardFooter: HmrcStandardFooter,
-    trackingConsentSnippet: TrackingConsentSnippet
-)
+      govukHeader: GovukHeader,
+      standardBetaBanner: StandardBetaBanner,
+      hmrcReportTechnicalIssue: HmrcReportTechnicalIssue,
+      hmrcLanguageSelect: HmrcLanguageSelect,
+      hmrcTimeoutDialog: HmrcTimeoutDialog,
+      hmrcStandardHeader: HmrcStandardHeader,
+      hmrcStandardFooter: HmrcStandardFooter,
+      hmrcTrackingConsentSnippet: HmrcTrackingConsentSnippet)
 
 @(pageTitle: String,
   showSignOut: Boolean = true,
   feedbackOnSignOut: Boolean = true,
   user: Option[User[_]] = None)(mainContent: Html)(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
-
 
 @titleServiceName = @{
     user.fold(messages("navTitle.vat"))(u => if(u.isAgent) messages("navTitle.agent") else messages("navTitle.nonAgent"))
@@ -50,18 +47,7 @@
     <script>window.HMRCFrontend.initAll();</script>
 }
 
-@phaseBannerContent = {
-    @messages("feedback.before")
-    <a id="beta-banner-feedback" class="govuk-link" href="@appConfig.betaFeedbackUrl">
-      @messages("feedback.link")</a>
-    @messages("feedback.after")
-}
-
 @beforeContentHtml = {
-  @govukPhaseBanner(PhaseBanner(
-    tag = Some(Tag(content = Text(messages("banner.phaseName")))),
-    content = HtmlContent(phaseBannerContent)
-  ))
   @hmrcLanguageSelect(LanguageSelect(
     language = if (messages.lang.language == "en") En else Cy,
     languageLinks =
@@ -71,8 +57,8 @@
 }
 
 @head = {
-@trackingConsentSnippet(nonce = None)
-<link rel="stylesheet" type="text/css" href='@routes.Assets.at("stylesheets/application.css")' media="all">
+  @hmrcTrackingConsentSnippet()
+  <link rel="stylesheet" type="text/css" href='@routes.Assets.at("stylesheets/application.css")' media="all">
 
     @if(showSignOut) {
         @hmrcTimeoutDialog(TimeoutDialog(
@@ -81,21 +67,17 @@
          signOutUrl = Some(routes.SignOutController.signOut(feedbackOnSignOut = false).url),
          keepAliveUrl = Some("#"),
          signOutButtonText = Some(messages("base.signOut"))
-    ))
+      ))
     }
 }
 
 @header = @{
-    govukHeader(Header(
-        serviceName = Some(titleServiceName),
-        navigation =
-         if(showSignOut)
-              Some(Seq(HeaderNavigation(
-                text = Some(messages("base.signOut")),
-                href = Some(routes.SignOutController.signOut(feedbackOnSignOut).url)
-              )))
-        else None
-    ))
+  hmrcStandardHeader(
+    serviceName = Some(titleServiceName),
+    signOutUrl = if(showSignOut) Some(routes.SignOutController.signOut(feedbackOnSignOut).url) else None,
+    phaseBanner = Some(standardBetaBanner(url = appConfig.betaFeedbackUrl)),
+    displayHmrcBanner = false
+  )
 }
 
 @getHelpHtml = @{hmrcReportTechnicalIssue(ReportTechnicalIssue(

--- a/app/views/errors/UnauthorisedAgent.scala.html
+++ b/app/views/errors/UnauthorisedAgent.scala.html
@@ -32,6 +32,6 @@
 
     @govukButton(Button(
     href = Some(routes.SignOutController.signOut(feedbackOnSignOut = false).url),
-    content = Text(messages("common.signOut"))
+    content = Text(messages("base.signOut"))
     ))
 }

--- a/app/views/errors/UnauthorisedNonAgent.scala.html
+++ b/app/views/errors/UnauthorisedNonAgent.scala.html
@@ -33,6 +33,6 @@
 
     @govukButton(Button(
     href = Some(routes.SignOutController.signOut(feedbackOnSignOut = false).url),
-    content = Text(messages("common.signOut"))
+    content = Text(messages("base.signOut"))
     ))
 }

--- a/app/views/returnFrequency/ChooseDates.scala.html
+++ b/app/views/returnFrequency/ChooseDates.scala.html
@@ -18,7 +18,6 @@
 @import models.returnFrequency._
 @import models.auth.User
 @import views.html.MainTemplate
-@import uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
 @import config.AppConfig
 
 @this(mainTemplate: MainTemplate,

--- a/app/views/returnFrequency/ConfirmDates.scala.html
+++ b/app/views/returnFrequency/ConfirmDates.scala.html
@@ -15,7 +15,6 @@
  *@
 
 @import models.returnFrequency.ReturnPeriod
-@import uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
 @import models.auth.User
 @import views.html.MainTemplate
 

--- a/build.sbt
+++ b/build.sbt
@@ -54,15 +54,14 @@ lazy val coverageSettings: Seq[Setting[_]] = {
 
 val compile = Seq(
   play.sbt.PlayImport.ws,
-  "uk.gov.hmrc"    %% "govuk-template"                % "5.63.0-play-26",
-  "uk.gov.hmrc"    %% "play-ui"                       % "9.0.0-play-26",
-  "uk.gov.hmrc"    %% "bootstrap-frontend-play-26"    % "3.4.0",
-  "uk.gov.hmrc"    %% "play-partials"                 % "7.1.0-play-26",
+  "uk.gov.hmrc"    %% "govuk-template"                % "5.66.0-play-26",
+  "uk.gov.hmrc"    %% "bootstrap-frontend-play-26"    % "5.3.0",
+  "uk.gov.hmrc"    %% "play-partials"                 % "8.1.0-play-26",
   "org.typelevel"  %% "cats"                          % "0.9.0",
   "uk.gov.hmrc"    %% "play-whitelist-filter"         % "3.4.0-play-26",
-  "uk.gov.hmrc"    %% "play-language"                 % "4.10.0-play-26",
-  "uk.gov.hmrc"    %% "play-frontend-govuk"           % "0.65.0-play-26",
-  "uk.gov.hmrc"    %% "play-frontend-hmrc"            % "0.50.0-play-26"
+  "uk.gov.hmrc"    %% "play-language"                 % "5.0.0-play-26",
+  "uk.gov.hmrc"    %% "play-frontend-govuk"           % "0.73.0-play-26",
+  "uk.gov.hmrc"    %% "play-frontend-hmrc"            % "0.66.0-play-26"
 )
 
 val test = Seq(
@@ -90,7 +89,7 @@ TwirlKeys.templateImports ++= Seq(
 )
 
 lazy val microservice: Project = Project(appName, file("."))
-  .enablePlugins(Seq(play.sbt.PlayScala, SbtAutoBuildPlugin, SbtGitVersioning, SbtDistributablesPlugin) ++ plugins: _*)
+  .enablePlugins(Seq(play.sbt.PlayScala, SbtDistributablesPlugin) ++ plugins: _*)
   .disablePlugins(JUnitXmlReportPlugin)
   .settings(PlayKeys.playDefaultPort := 9167)
   .settings(coverageSettings: _*)
@@ -115,8 +114,5 @@ lazy val microservice: Project = Project(appName, file("."))
     addTestReportOption(IntegrationTest, "int-test-reports"),
     testGrouping in IntegrationTest := oneForkedJvmPerTest((definedTests in IntegrationTest).value),
     parallelExecution in IntegrationTest := false,
-    resourceDirectory in IntegrationTest := baseDirectory.value / "it" / "resources")
-  .settings(resolvers ++= Seq(
-    Resolver.bintrayRepo("hmrc", "releases"),
-    Resolver.jcenterRepo
-  ))
+    resourceDirectory in IntegrationTest := baseDirectory.value / "it" / "resources"
+  )

--- a/conf/messages
+++ b/conf/messages
@@ -10,11 +10,6 @@ common.error = Error:
 base.back = Back
 base.signOut = Sign out
 
-feedback.before = This is a new service – your
-feedback.link = feedback
-feedback.after = will help us to improve it.
-banner.phaseName = BETA
-
 featureSwitch.title = Feature switches
 featureSwitch.heading = Features
 featureSwitch.submit = Submit

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -10,11 +10,6 @@ common.error = Gwall:
 base.back = Yn ôl
 base.signOut = Allgofnodi
 
-feedback.before = Gwasanaeth newydd yw hwn – bydd eich
-feedback.link = adborth
-feedback.after = yn ein helpu i’w wella.
-banner.phaseName = BETA
-
 featureSwitch.title = Feature switches
 featureSwitch.heading = Nodweddion
 featureSwitch.submit = Cyflwyno

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -15,14 +15,11 @@
  */
 
 resolvers += Resolver.url("HMRC Sbt Plugin Releases", url("https://dl.bintray.com/hmrc/sbt-plugin-releases"))(Resolver.ivyStylePatterns)
-
-resolvers += "HMRC Releases" at "https://dl.bintray.com/hmrc/releases"
-
+resolvers += MavenRepository("HMRC-open-artefacts-maven2", "https://open.artefacts.tax.service.gov.uk/maven2")
+resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 resolvers += "Typesafe Releases" at "https://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.13.0")
-
-addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.2.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.0.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.1.0")
 

--- a/test/mocks/MockHttp.scala
+++ b/test/mocks/MockHttp.scala
@@ -29,12 +29,14 @@ trait MockHttp extends UnitSpec with MockFactory {
   val mockHttp: HttpClient = mock[HttpClient]
 
   def setupMockHttpGet[T](url: String)(response: T): Unit =
-    (mockHttp.GET[T](_: String)(_: HttpReads[T], _: HeaderCarrier, _: ExecutionContext))
-      .expects(*, *, *, *)
+    (mockHttp.GET[T](_: String, _: Seq[(String, String)], _: Seq[(String, String)])
+                    (_: HttpReads[T], _: HeaderCarrier, _: ExecutionContext))
+      .expects(*, *, *, *, *, *)
       .returns(response)
 
   def setupMockHttpPut[I,O](url: String)(response: O): Unit =
-    (mockHttp.PUT[I,O](_: String, _: I, _: Seq[(String, String)])(_: Writes[I], _: HttpReads[O], _: HeaderCarrier, _: ExecutionContext))
+    (mockHttp.PUT[I,O](_: String, _: I, _: Seq[(String, String)])
+                      (_: Writes[I], _: HttpReads[O], _: HeaderCarrier, _: ExecutionContext))
       .expects(*, *, *, *, *, *, *)
       .returns(response)
 


### PR DESCRIPTION
As part of this work I have also removed `play-ui` as a dependency as this is being phased out on the platform and no longer required in this service (`TrackingConsentSnippet` is replaced by `HmrcTrackingConsentSnippet`). Some CSS relating to the header was removed as the component applies these fixes already.